### PR TITLE
Introducing s3-cloudfront-report tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every script should follow single responsibility principle and should be a separ
 
  Script | Description | Maintenance or Provision | Implementation status
  --- | --- | --- | ---
- s3-cloudfront-report | List S3 buckets with connected Cloudfront distributions sorted by size. | M | To do
+ s3-cloudfront-report | List S3 buckets with connected Cloudfront distributions sorted by size. | M | Done
  ec2-snapshoter | Sets up CloudWatch scheduled expression to take snaphot of all ec2 volumes every 24h | M/P | Done
  iam-scan | Lists all IAM users with associated rules, detects too wide permissions and unused accounts/roles/policies | M | To do
  iam-repair | Fixes issues found by `iam-scan` | M | To do
@@ -39,4 +39,3 @@ Every script should follow single responsibility principle and should be a separ
 - Clone this repository to `$GOPATH/src/netguru/aws-guru`
 - Run `go get`
 - Build & Run the app `go run main.go [arg]`
-

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Every script should follow single responsibility principle and should be a separ
  budgeter | Creates budgets for EC2, RDS, S3 & Cloudfront usage. | P | To do
  disaster-recovery | Provisions EC2 instance and RDS instance basing on last snapshot provided | M | To do
 
+### Development
+
+- Clone this repository to `$GOPATH/src/netguru/aws-guru`
+- Run `go get`
+- Build & Run the app `go run main.go [arg]`
+

--- a/aws/cloudfront.go
+++ b/aws/cloudfront.go
@@ -1,0 +1,16 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+func CreateCloudfrontContext(sess *session.Session) *cloudfront.CloudFront {
+	return cloudfront.New(sess)
+}
+
+func ListDistributions(svc *cloudfront.CloudFront) (*cloudfront.DistributionList, error) {
+	params := &cloudfront.ListDistributionsInput{}
+	resp, err := svc.ListDistributions(params)
+	return resp.DistributionList, err
+}

--- a/aws/main.go
+++ b/aws/main.go
@@ -1,13 +1,22 @@
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 func CreateSession(region *string) *session.Session {
 	sess := session.Must(session.NewSession(&aws.Config{
 		Region: aws.String(*region),
+	}))
+
+	return sess
+}
+
+func CreateProfiledSession(region *string, profile *string) *session.Session {
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config:  aws.Config{Region: aws.String(*region)},
+		Profile: *profile,
 	}))
 
 	return sess

--- a/aws/s3.go
+++ b/aws/s3.go
@@ -1,0 +1,16 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func CreateS3Context(sess *session.Session) *s3.S3 {
+	return s3.New(sess)
+}
+
+func ListBuckets(svc *s3.S3) ([]*s3.Bucket, error) {
+	params := &s3.ListBucketsInput{}
+	resp, err := svc.ListBuckets(params)
+	return resp.Buckets, err
+}

--- a/cmd/ec2-snapshoter.go
+++ b/cmd/ec2-snapshoter.go
@@ -20,12 +20,6 @@ var ec2snapshoterCmd = &cobra.Command{
 	},
 }
 
-var cronPattern string
-var cronName string
-var region string
-var accountId string
-var reattachOnly bool
-
 func init() {
 	ec2snapshoterCmd.Flags().StringVarP(&cronPattern, "cron-pattern", "c", "0 10 * * ? *", "scheduled expression cron pattern (UTC time)")
 	ec2snapshoterCmd.Flags().StringVarP(&cronName, "cron-name", "n", "ec2-snapshoter", "name of the scheduled expression")

--- a/cmd/ec2-snapshoter.go
+++ b/cmd/ec2-snapshoter.go
@@ -1,20 +1,20 @@
 package cmd
 
 import (
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/aws/aws-sdk-go/aws"
-	awslib "aws-guru/aws"
-	"aws-guru/utils"
-	"github.com/spf13/cobra"
+	"github.com/aws/aws-sdk-go/service/cloudwatchevents"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	awslib "netguru/aws-guru/aws"
+	"netguru/aws-guru/utils"
 )
 
 var ec2snapshoterCmd = &cobra.Command{
 	Use:   "ec2-snapshoter",
 	Short: "Setup automatic EC2 snapshots using Cloudwatch Events",
-	Long: `EC2 Snapshoter configures a scheduled expression (Cloudwatch Event) which will take snapshot of your EC2 volumes every X hours.`,
+	Long:  `EC2 Snapshoter configures a scheduled expression (Cloudwatch Event) which will take snapshot of your EC2 volumes every X hours.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ec2SnapshoterRun()
 	},
@@ -51,15 +51,14 @@ func prepareCloudWatchEventTargets(region, accountId, stackName string, volumes 
 
 	for i, volume := range volumes {
 		targets[i] = &cloudwatchevents.Target{
-			Arn: aws.String(getAutomationTargetArnName(region, accountId, stackName)),
-			Id:  aws.String(fmt.Sprintf("id_%d", i)),
+			Arn:   aws.String(getAutomationTargetArnName(region, accountId, stackName)),
+			Id:    aws.String(fmt.Sprintf("id_%d", i)),
 			Input: aws.String(getEC2VolumeInputArnName(region, accountId, *volume.VolumeId)),
 		}
 	}
 
 	return targets
 }
-
 
 func ec2SnapshoterRun() {
 	sess := awslib.CreateSession(&region)
@@ -69,7 +68,8 @@ func ec2SnapshoterRun() {
 
 	fmt.Println("Listing volumes...")
 
-	volumes, err := awslib.ListVolumes(ec2Svc); if err != nil {
+	volumes, err := awslib.ListVolumes(ec2Svc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
@@ -112,7 +112,8 @@ func ec2SnapshoterRun() {
 		cronName,
 		prepareCloudWatchEventTargets(region, accountId, "stack", volumes),
 		cloudwatchEventsSvc,
-	); if err != nil {
+	)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,14 +9,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
 var RootCmd = &cobra.Command{
 	Use:   "aws-guru",
 	Short: "Set of scripts for AWS Accounts provisioning and maintenance",
-	Long: `AWS-guru is a CLI that empowers devops in provisioning and maintaining AWS accounts by automating their work.`,
+	Long:  `AWS-guru is a CLI that empowers devops in provisioning and maintaining AWS accounts by automating their work.`,
 }
-
 
 func init() {
 	cobra.OnInitialize(initConfig)

--- a/cmd/s3-cloudfront-report.go
+++ b/cmd/s3-cloudfront-report.go
@@ -1,7 +1,20 @@
 package cmd
 
 import (
+	"fmt"
+	awslib "netguru/aws-guru/aws"
+	"netguru/aws-guru/utils"
+
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
 	"github.com/spf13/cobra"
+
+	"code.cloudfoundry.org/bytefmt"
 )
 
 var s3CloudfrontReportCmd = &cobra.Command{
@@ -10,9 +23,132 @@ var s3CloudfrontReportCmd = &cobra.Command{
 	Long:  `List S3 buckets with connected Cloudfront distributions sorted by size.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		s3CloudfrontReportRun()
 	},
 }
 
+type bucketDistro struct {
+	Bucket   string
+	CfDistro string
+}
+
+type s3CloudfrontReportJSON struct {
+	Bucket    string `json:"bucket"`
+	CfURL     string `json:"cf_url"`
+	Region    string `json:"region"`
+	Size      int64  `json:"size"`
+	SizeHuman string `json:"size_human"`
+}
+
 func init() {
+	s3CloudfrontReportCmd.Flags().StringVarP(&region, "region", "r", "us-east-1", "region")
+	s3CloudfrontReportCmd.Flags().StringVarP(&profile, "profile", "p", "default", "profile to use with credentials")
+	s3CloudfrontReportCmd.Flags().StringVarP(&format, "format", "f", "table", "output format (table/json)")
 	RootCmd.AddCommand(s3CloudfrontReportCmd)
+}
+
+func s3CloudfrontReportRun() {
+	sess := awslib.CreateProfiledSession(&region, &profile)
+	cfSvc := awslib.CreateCloudfrontContext(sess)
+
+	fmt.Printf("Looking for CF distributions connected with s3... ")
+
+	distro, err := awslib.ListDistributions(cfSvc)
+	if err != nil {
+		utils.ExitWithError(err)
+	}
+
+	var buckets []bucketDistro
+
+	for _, item := range distro.Items {
+		for _, origin := range item.Origins.Items {
+			if strings.Contains(*origin.DomainName, ".s3.amazonaws.com") {
+				buckets = append(buckets, bucketDistro{Bucket: *origin.DomainName, CfDistro: *item.DomainName})
+			}
+		}
+	}
+
+	if len(buckets) > 0 {
+		fmt.Printf("Found %d buckets\n", len(buckets))
+		calculateBucketSizes(buckets)
+	} else {
+		fmt.Printf("No buckets found\n")
+	}
+}
+
+func fetchBucketName(domainName string) string {
+	splitted := strings.Split(domainName, ".s3.amazonaws.com")
+	return splitted[0]
+}
+
+func fetchBucketRegion(bucket string, sess *session.Session) string {
+	ctx := context.Background()
+
+	bucketRegion, err := s3manager.GetBucketRegion(ctx, sess, bucket, region)
+	if err != nil {
+		utils.ExitWithError(err)
+	}
+
+	return bucketRegion
+}
+
+func calculateBucketSizes(buckets []bucketDistro) {
+	sess := awslib.CreateProfiledSession(&region, &profile)
+	output := []s3CloudfrontReportJSON{}
+
+	for _, bd := range buckets {
+		distro := bd.CfDistro
+		bucket := fetchBucketName(bd.Bucket)
+
+		bucketRegion := fetchBucketRegion(bucket, sess)
+
+		sess = awslib.CreateProfiledSession(&bucketRegion, &profile)
+		s3Svc := awslib.CreateS3Context(sess)
+
+		input := &s3.ListObjectsV2Input{
+			Bucket: &bucket,
+		}
+
+		var bucketSize int64
+
+		err := s3Svc.ListObjectsV2Pages(input, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+			fmt.Print(".")
+			for _, obj := range page.Contents {
+				bucketSize = bucketSize + *obj.Size
+			}
+			return lastPage
+		})
+
+		if err != nil {
+			utils.ExitWithError(err)
+		}
+
+		output = append(output, s3CloudfrontReportJSON{
+			Bucket:    bucket,
+			CfURL:     distro,
+			Region:    bucketRegion,
+			Size:      bucketSize,
+			SizeHuman: bytefmt.ByteSize(uint64(bucketSize)),
+		})
+	}
+
+	fmt.Print("\n\n")
+
+	switch format {
+	case "json":
+		utils.PrintJSON(output)
+	default:
+		utils.PrintTable(s3CloudfrontReportToTable(output), []string{"Bucket", "CF URL", "Region", "Size"})
+	}
+
+}
+
+func s3CloudfrontReportToTable(json []s3CloudfrontReportJSON) [][]string {
+	table := [][]string{}
+
+	for _, item := range json {
+		table = append(table, []string{item.Bucket, item.CfURL, item.Region, item.SizeHuman})
+	}
+
+	return table
 }

--- a/cmd/s3-cloudfront-report.go
+++ b/cmd/s3-cloudfront-report.go
@@ -1,11 +1,13 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 var s3CloudfrontReportCmd = &cobra.Command{
 	Use:   "s3-cloudfront-report",
 	Short: "List S3 buckets with connected Cloudfront distributions sorted by size.",
-	Long: `List S3 buckets with connected Cloudfront distributions sorted by size.`,
+	Long:  `List S3 buckets with connected Cloudfront distributions sorted by size.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 	},

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -1,0 +1,13 @@
+package cmd
+
+var cronPattern string
+var cronName string
+var region string
+var accountId string
+var reattachOnly bool
+var cfgFile string
+var vpcCidr string
+var privateSubnetCidr string
+var publicSubnetCidr string
+var profile string
+var format string

--- a/cmd/vpc-setup.go
+++ b/cmd/vpc-setup.go
@@ -17,10 +17,6 @@ var vpcSetupCmd = &cobra.Command{
 	},
 }
 
-var vpcCidr string
-var privateSubnetCidr string
-var publicSubnetCidr string
-
 func init() {
 	vpcSetupCmd.Flags().StringVarP(&vpcCidr, "vpc-cidr", "v", "10.0.0.0/16", "VPC CIDR")
 	vpcSetupCmd.Flags().StringVarP(&privateSubnetCidr, "private-cidr", "r", "10.0.0.0/24", "Private Subnet CIDR")

--- a/cmd/vpc-setup.go
+++ b/cmd/vpc-setup.go
@@ -2,15 +2,15 @@ package cmd
 
 import "github.com/spf13/cobra"
 import (
-	awslib "aws-guru/aws"
-	"aws-guru/utils"
 	"fmt"
+	awslib "netguru/aws-guru/aws"
+	"netguru/aws-guru/utils"
 )
 
 var vpcSetupCmd = &cobra.Command{
 	Use:   "vpc-setup",
 	Short: "Provisions VPC and Subnets suitable for future development",
-	Long: `Provisions VPC and Subnets suitable for future development`,
+	Long:  `Provisions VPC and Subnets suitable for future development`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		vpcSetupRun()
@@ -35,25 +35,29 @@ func vpcSetupRun() {
 
 	fmt.Println("Creating VPC...")
 
-	vpcResult, err := awslib.CreateVPC(vpcCidr, *vpcSvc); if err != nil {
+	vpcResult, err := awslib.CreateVPC(vpcCidr, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
 	fmt.Println("Creating private subnet...")
 
-	_, err = awslib.CreateSubnet(privateSubnetCidr, *vpcResult.Vpc.VpcId, *vpcSvc); if err != nil {
+	_, err = awslib.CreateSubnet(privateSubnetCidr, *vpcResult.Vpc.VpcId, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
 	fmt.Println("Creating public subnet...")
 
-	publicSubnetResult, err := awslib.CreateSubnet(publicSubnetCidr, *vpcResult.Vpc.VpcId, *vpcSvc); if err != nil {
+	publicSubnetResult, err := awslib.CreateSubnet(publicSubnetCidr, *vpcResult.Vpc.VpcId, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
 	fmt.Println("Creating Internet Gateway...")
 
-	ipgwResult, err := awslib.CreateInternetGateway(*vpcSvc); if err != nil {
+	ipgwResult, err := awslib.CreateInternetGateway(*vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
@@ -67,21 +71,24 @@ func vpcSetupRun() {
 
 	fmt.Println("Creating Route Table...")
 
-	routeTableResult, err := awslib.CreateRouteTable(*vpcResult.Vpc.VpcId, *vpcSvc); if err != nil {
+	routeTableResult, err := awslib.CreateRouteTable(*vpcResult.Vpc.VpcId, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
 	fmt.Println("Creating Route...")
 
 	err = awslib.CreateRoute("0.0.0.0/0", *ipgwResult.InternetGateway.InternetGatewayId,
-		*routeTableResult.RouteTable.RouteTableId, *vpcSvc); if err != nil {
+		*routeTableResult.RouteTable.RouteTableId, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 
 	fmt.Println("Attaching Route Table to Subnet...")
 
 	err = awslib.AttachRouteTableToSubnet(*routeTableResult.RouteTable.RouteTableId,
-		*publicSubnetResult.Subnet.SubnetId, *vpcSvc); if err != nil {
+		*publicSubnetResult.Subnet.SubnetId, *vpcSvc)
+	if err != nil {
 		utils.ExitWithError(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"aws-guru/cmd"
 	"fmt"
+	"netguru/aws-guru/cmd"
 	"os"
 )
 

--- a/utils/error.go
+++ b/utils/error.go
@@ -1,11 +1,39 @@
 package utils
 
 import (
-	"os"
+	"encoding/json"
 	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
 )
 
+// ExitWithError prints out error and exits program with status code 1
 func ExitWithError(err error) {
 	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	os.Exit(1)
+}
+
+// PrintJSON prints to stdout marshaled JSON
+//  Given argument should be any marshal - compatibile data structure
+func PrintJSON(data interface{}) {
+	json, err := json.Marshal(data)
+	if err != nil {
+		ExitWithError(err)
+	}
+
+	fmt.Println(string(json))
+}
+
+// PrintTable prints to stdout an ascii table using github.com/olekukonko/tablewriter library
+// Arguments are:
+//   data: [][]string, data that should be printed as table
+//   header: []string, headers of the table
+func PrintTable(data [][]string, header []string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(header)
+	table.SetBorder(false)
+	table.AppendBulk(data)
+
+	table.Render()
 }


### PR DESCRIPTION
* Use "s3-cloudfront-report" to search for connection between s3 and
CF, prints out (as table or json) the sizes of buckets and
corresponding CF distributions
* Fix some linter issues
* Move common variables to separate file
* Add some comments to methods

Prints out following info:

```
            BUCKET           |            CF URL             |    REGION    |  SIZE
+----------------------------+-------------------------------+--------------+--------+
  m[.........]               | dw[..........].cloudfront.net | us-east-1    | 16.8M
  n[.........]               | d2[..........].cloudfront.net | us-east-1    | 162.6M
  s[.........]               | d3[..........].cloudfront.net | eu-west-1    | 188.2M
  r[.........]               | d3[..........].cloudfront.net | us-east-1    | 429.5M
  j[.........]               | d2[..........].cloudfront.net | eu-central-1 | 230.4M
  a[.........]               | d2[..........].cloudfront.net | eu-central-1 | 13.4M
  u[.........]               | d2[..........].cloudfront.net | eu-west-1    | 112.8M
  b[.........]               | dg[..........].cloudfront.net | eu-central-1 | 11.7M
  u[.........]               | d6[..........].cloudfront.net | eu-west-1    | 18.6M
  s[.........]               | d1[..........].cloudfront.net | eu-central-1 | 1.8M
  a[.........]               | d2[..........].cloudfront.net | eu-central-1 |    0
  d[.........]               | dd[..........].cloudfront.net | eu-west-1    | 945.5K
  m[.........]               | d1[..........].cloudfront.net | eu-central-1 | 3.3M
```

As well as in json format, given `--format json` in argument